### PR TITLE
stop for loop once condition is met

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func WriteToLidIds(oldIds []string, id string, lid string, state map[string][]st
 	for _, v := range oldIds {
 		if v == id {
 			hasID = true
+			return // exit for loop as soon as we find a match
 		}
 	}
 


### PR DESCRIPTION
Exit as soon as item is found in for loop

apparently go exits loops with the `return` keyword